### PR TITLE
Fix: edits.track().update  should be called  two times (Track alpha -…

### DIFF
--- a/v2/java/src/com/google/play/developerapi/samples/BasicUploadApk.java
+++ b/v2/java/src/com/google/play/developerapi/samples/BasicUploadApk.java
@@ -52,6 +52,7 @@ public class BasicUploadApk {
      * 'rollout'.
      */
     private static final String TRACK_ALPHA = "alpha";
+    private static final String TRACK_BETA = "beta";
 
     public static void main(String[] args) {
         try {
@@ -88,15 +89,29 @@ public class BasicUploadApk {
 
             // Assign apk to alpha track.
             List<Integer> apkVersionCodes = new ArrayList<>();
-            apkVersionCodes.add(apk.getVersionCode());
+
+            //untrack beta
             Update updateTrackRequest = edits
+                .tracks()
+                .update(ApplicationConfig.PACKAGE_NAME,
+                    editId,
+                    TRACK_BETA,
+                    new Track().setVersionCodes(apkVersionCodes);
+            Track updatedTrack =updateTrackRequest.execute();
+            log.info(String.format("Track %s has been updated.", updatedTrack.getTrack()));
+
+            //track alpha
+            apkVersionCodes.add(apk.getVersionCode());
+            Update updateTrackRequest2 = edits
                     .tracks()
                     .update(ApplicationConfig.PACKAGE_NAME,
                             editId,
                             TRACK_ALPHA,
                             new Track().setVersionCodes(apkVersionCodes));
-            Track updatedTrack = updateTrackRequest.execute();
-            log.info(String.format("Track %s has been updated.", updatedTrack.getTrack()));
+            Track updatedTrack2 = updateTrackRequest2.execute();
+            log.info(String.format("Track %s has been updated.", updatedTrack2.getTrack()));
+
+
 
             // Commit changes for edit.
             Commit commitRequest = edits.commit(ApplicationConfig.PACKAGE_NAME, editId);


### PR DESCRIPTION
Fix: edits.track().update  should be called  two times.

--> I'am not able to commit my edits and im getting every time error 403 ... -->

 `{ "code" : 403, "errors" : [ { "domain" : "androidpublisher", "message" : "Version 3 of this app can not be downloaded by any devices as they will all receive APKs with higher version codes.", "reason" : "multiApkShadowedActiveApk" } ], "message" : "Version 3 of this app can not be downloaded by any devices as they will all receive APKs with higher version codes." }`

I beleive that the problem is that using the sample class "BasicUploadApk" you are tracking alpha with a new apk where another apk (with different versionCode) is in the same time tracked in beta.

--> result `multiApkShadowedActiveApk` error!

please see similar issues here:

- [https://github.com/Triple-T/gradle-play-publisher/issues/121](url)

- [https://github.com/Triple-T/gradle-play-publisher/issues/135](url)

thank you 