### PR TITLE
Fix "Invalid value for versionCodes: [XXX]"

### DIFF
--- a/v3/python/basic_upload_apks.py
+++ b/v3/python/basic_upload_apks.py
@@ -65,7 +65,7 @@ def main(argv):
         packageName=package_name,
         body={u'releases': [{
             u'name': u'My first API release',
-            u'versionCodes': [str([apk_response['versionCode']])],
+            u'versionCodes': [str(apk_response['versionCode'])],
             u'status': u'completed',
         }]}).execute()
 


### PR DESCRIPTION
The version code was being sent as an array inside an array, raising the following error:
`<HttpError 400 when requesting https://www.googleapis.com/androidpublisher/v3/applications/com.xxx.xxx/edits/xxx/tracks/beta?alt=json returned "Invalid value for versionCodes: [100921]">`.
Removed the extra square brackets.