### PR TITLE
Migrate [DEPRECATED]SignedJwtAssertionCredentials to ServiceAccountCredentials

### DIFF
--- a/v3/python/basic_list_apks_service_account.py
+++ b/v3/python/basic_list_apks_service_account.py
@@ -21,6 +21,7 @@ import argparse
 from apiclient.discovery import build
 import httplib2
 from oauth2client import client
+from oauth2client.service_account import ServiceAccountCredentials
 
 
 SERVICE_ACCOUNT_EMAIL = (
@@ -35,9 +36,7 @@ argparser.add_argument('package_name',
 def main():
   # Load the key in PKCS 12 format that you downloaded from the Google APIs
   # Console when you created your Service account.
-  f = file('key.p12', 'rb')
-  key = f.read()
-  f.close()
+  key = 'key.p12'
 
   # Create an httplib2.Http object to handle our HTTP requests and authorize it
   # with the Credentials. Note that the first parameter, service_account_name,
@@ -46,7 +45,7 @@ def main():
   credentials = client.SignedJwtAssertionCredentials(
       SERVICE_ACCOUNT_EMAIL,
       key,
-      scope='https://www.googleapis.com/auth/androidpublisher')
+      scopes=['https://www.googleapis.com/auth/androidpublisher'])
   http = httplib2.Http()
   http = credentials.authorize(http)
 


### PR DESCRIPTION
Explanation:
SignedJwtAssertionCredentials was removed from the oath2client python package in the 2.0.0 update. It was no more under oauth2client.client. The behaviour has been moved onto oauth2client.service_account.ServiceAccountCredentials.

See [this SO thread](https://stackoverflow.com/a/35666374/12675239) for more info.

## Additional Notes

Developers need to perform following tasks on their dependencies in order for this to work:

`pip install pyOpenSSL`
`pip install --upgrade oauth2client`